### PR TITLE
Add dummy diagnostic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,11 @@ Multimodal AI medical assistant: voice, vision, and diagnostic reasoning.
 An `examples/` directory contains demonstration code. Run the dummy diagnostic example with:
 
 ```bash
-python examples/dummy_diagnostic.py
+python examples/dummy_diagnostic.py --symptoms "fever,cough"
+```
+
+Another example demonstrates a tiny AI-based SAP Basis log classifier:
+
+```bash
+python examples/sap_basis_monitor.py examples/sap_sample_log.txt
 ```

--- a/examples/dummy_diagnostic.py
+++ b/examples/dummy_diagnostic.py
@@ -16,7 +16,22 @@ def diagnose(symptoms):
     return "Unknown - consult a professional"
 
 if __name__ == "__main__":
-    user_input = input("Enter symptoms separated by comma: ")
-    symptoms = [s.strip().lower() for s in user_input.split(',')]
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Run a toy diagnostic based on comma-separated symptoms"
+    )
+    parser.add_argument(
+        "--symptoms",
+        help="Comma-separated list of symptoms. If omitted, prompt interactively.",
+    )
+    args = parser.parse_args()
+
+    if args.symptoms:
+        raw_input = args.symptoms
+    else:
+        raw_input = input("Enter symptoms separated by comma: ")
+
+    symptoms = [s.strip().lower() for s in raw_input.split(",") if s.strip()]
     result = diagnose(symptoms)
     print(f"Possible diagnosis: {result}")

--- a/examples/sap_basis_monitor.py
+++ b/examples/sap_basis_monitor.py
@@ -1,0 +1,76 @@
+"""Simple SAP Basis monitoring demo using naive Bayes text classification."""
+
+from collections import Counter, defaultdict
+import math
+import argparse
+
+TRAINING_DATA = [
+    ("Work process restart completed successfully", "INFO"),
+    ("Database connection lost", "ERROR"),
+    ("Background job ended with warnings", "WARNING"),
+    ("Kernel fault - memory allocation error", "ERROR"),
+    ("User login successful", "INFO"),
+    ("System log full", "ERROR"),
+    ("Dispatcher running", "INFO"),
+    ("Update failed due to lock", "ERROR"),
+]
+
+class NaiveBayes:
+    def __init__(self):
+        self.class_counts = Counter()
+        self.word_counts = defaultdict(Counter)
+        self.vocab = set()
+        self.total_docs = 0
+
+    def train(self, data):
+        for text, label in data:
+            self.class_counts[label] += 1
+            for word in text.lower().split():
+                self.word_counts[label][word] += 1
+                self.vocab.add(word)
+        self.total_docs = sum(self.class_counts.values())
+
+    def predict(self, text):
+        words = text.lower().split()
+        best_label = None
+        best_score = -float("inf")
+        for label in self.class_counts:
+            log_prob = math.log(self.class_counts[label] / self.total_docs)
+            total_words = sum(self.word_counts[label].values())
+            for word in words:
+                log_prob += math.log(
+                    (self.word_counts[label][word] + 1)
+                    / (total_words + len(self.vocab))
+                )
+            if log_prob > best_score:
+                best_score = log_prob
+                best_label = label
+        return best_label
+
+
+def classify_logs(log_lines):
+    nb = NaiveBayes()
+    nb.train(TRAINING_DATA)
+    results = []
+    for line in log_lines:
+        label = nb.predict(line)
+        results.append((line.strip(), label))
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Classify SAP log lines")
+    parser.add_argument(
+        "logfile", nargs="?", default="sap_sample_log.txt", help="Path to log file"
+    )
+    args = parser.parse_args()
+
+    with open(args.logfile, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    for line, label in classify_logs(lines):
+        print(f"{label}: {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sap_sample_log.txt
+++ b/examples/sap_sample_log.txt
@@ -1,0 +1,8 @@
+Dispatcher running
+Database connection lost
+User login successful
+Update failed due to lock
+Work process restart completed successfully
+Kernel fault - memory allocation error
+Background job ended with warnings
+System log full


### PR DESCRIPTION
## Summary
- add example script showing a toy diagnostic reasoning process
- mention example in README

## Testing
- `python examples/dummy_diagnostic.py`

------
https://chatgpt.com/codex/tasks/task_b_68560c7611a48320a8dfd88498774575