### PR TITLE
Fix blank canvas rendering and add responsive arena resizing

### DIFF
--- a/streetfighter2.html
+++ b/streetfighter2.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Streetfighter II - Tiny Arena</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0c0f1a;
+      --panel: #151b2a;
+      --accent: #ff4757;
+      --accent-2: #1e90ff;
+      --text: #f1f2f6;
+      --health: #2ed573;
+      --danger: #ff6b81;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+    }
+
+    body {
+      background: radial-gradient(circle at top, #202945, var(--bg));
+      color: var(--text);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      min-height: 100vh;
+      padding: 32px 16px;
+      gap: 20px;
+    }
+
+    header {
+      text-align: center;
+      max-width: 720px;
+    }
+
+    header h1 {
+      font-size: 2.4rem;
+      margin-bottom: 8px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+
+    header p {
+      color: #c7c9d1;
+      line-height: 1.5;
+    }
+
+    .arena {
+      background: var(--panel);
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+      width: min(960px, 100%);
+    }
+
+    .hud {
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 12px;
+    }
+
+    .health-bar {
+      background: #2f3542;
+      border-radius: 999px;
+      overflow: hidden;
+      height: 18px;
+      position: relative;
+    }
+
+    .health-fill {
+      height: 100%;
+      transition: width 0.2s ease;
+      background: linear-gradient(90deg, var(--health), #7bed9f);
+    }
+
+    .health-fill.danger {
+      background: linear-gradient(90deg, var(--danger), #ff9ff3);
+    }
+
+    .round {
+      font-size: 1.2rem;
+      padding: 6px 16px;
+      background: #2b3144;
+      border-radius: 999px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 460px;
+      border-radius: 12px;
+      background: linear-gradient(180deg, #272f48 0%, #1d2236 100%);
+      border: 1px solid #2f3542;
+    }
+
+    .controls {
+      margin-top: 16px;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }
+
+    .control-card {
+      background: #1c2235;
+      border-radius: 12px;
+      padding: 12px 14px;
+      border: 1px solid #2d3550;
+    }
+
+    .control-card h3 {
+      font-size: 0.95rem;
+      margin-bottom: 6px;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+
+    .control-card ul {
+      list-style: none;
+      display: grid;
+      gap: 4px;
+      font-size: 0.9rem;
+      color: #b8bfd6;
+    }
+
+    .status {
+      margin-top: 12px;
+      padding: 10px 14px;
+      background: #1b2032;
+      border-radius: 10px;
+      border: 1px solid #2e364c;
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 10px;
+      font-size: 0.9rem;
+      color: #c9cee0;
+    }
+
+    .status strong {
+      color: var(--text);
+    }
+
+    button {
+      margin-top: 16px;
+      background: linear-gradient(120deg, var(--accent), #ffa502);
+      border: none;
+      padding: 10px 18px;
+      border-radius: 999px;
+      color: #fff;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      cursor: pointer;
+      box-shadow: 0 8px 20px rgba(255, 71, 87, 0.35);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 24px rgba(255, 71, 87, 0.45);
+    }
+
+    footer {
+      color: #98a0b9;
+      font-size: 0.8rem;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Streetfighter II: Mini Arena</h1>
+    <p>
+      A tiny reimagining of the classic arcade brawler. Pick up the keyboard and duel
+      with a friend locally. Trade punches, block incoming hits, and reset the match to
+      keep the rivalry going.
+    </p>
+  </header>
+
+  <section class="arena">
+    <div class="hud">
+      <div>
+        <div class="health-bar">
+          <div id="p1-health" class="health-fill"></div>
+        </div>
+      </div>
+      <div class="round" id="round-indicator">Round 1</div>
+      <div>
+        <div class="health-bar">
+          <div id="p2-health" class="health-fill"></div>
+        </div>
+      </div>
+    </div>
+    <canvas id="arena" width="900" height="460"></canvas>
+    <div class="status" id="status-text">
+      <span><strong>Ryu:</strong> Ready</span>
+      <span><strong>Chun-Li:</strong> Ready</span>
+      <span><strong>Tip:</strong> Press Space/Enter or Restart after K.O.</span>
+    </div>
+    <button id="reset">Restart Round</button>
+  </section>
+
+  <section class="controls">
+    <div class="control-card">
+      <h3>Ryu (Player 1)</h3>
+      <ul>
+        <li><strong>Move:</strong> A / D</li>
+        <li><strong>Jump:</strong> W</li>
+        <li><strong>Punch:</strong> F</li>
+        <li><strong>Block:</strong> S</li>
+      </ul>
+    </div>
+    <div class="control-card">
+      <h3>Chun-Li (Player 2)</h3>
+      <ul>
+        <li><strong>Move:</strong> J / L</li>
+        <li><strong>Jump:</strong> I</li>
+        <li><strong>Punch:</strong> H</li>
+        <li><strong>Block:</strong> K</li>
+      </ul>
+    </div>
+    <div class="control-card">
+      <h3>Goal</h3>
+      <ul>
+        <li>Land punches to reduce health.</li>
+        <li>Blocking reduces damage.</li>
+        <li>First fighter to 0 HP loses.</li>
+      </ul>
+    </div>
+  </section>
+
+  <footer>Streetfighter II is a Capcom property. This is a fan-made tribute.</footer>
+
+  <script>
+    const canvas = document.getElementById("arena");
+    const ctx = canvas.getContext("2d");
+
+    if (!ctx) {
+      document.body.innerHTML =
+        "<p style='color:#fff;padding:24px;font-family:Segoe UI, sans-serif;'>Your browser does not support the HTML5 canvas API required to play this game.</p>";
+      throw new Error("Canvas not supported");
+    }
+
+    const state = {
+      round: 1,
+      ground: 0,
+      arenaWidth: canvas.width,
+      arenaHeight: canvas.height,
+      gravity: 0.6,
+      fighters: [
+        {
+          name: "Ryu",
+          color: "#ff4757",
+          x: 180,
+          y: 0,
+          width: 70,
+          height: 110,
+          vx: 0,
+          vy: 0,
+          health: 100,
+          blocking: false,
+          punching: false,
+          punchCooldown: 0,
+          score: 0,
+          controls: {
+            left: "KeyA",
+            right: "KeyD",
+            jump: "KeyW",
+            punch: "KeyF",
+            block: "KeyS",
+          },
+        },
+        {
+          name: "Chun-Li",
+          color: "#1e90ff",
+          x: 640,
+          y: 0,
+          width: 70,
+          height: 110,
+          vx: 0,
+          vy: 0,
+          health: 100,
+          blocking: false,
+          punching: false,
+          punchCooldown: 0,
+          score: 0,
+          controls: {
+            left: "KeyJ",
+            right: "KeyL",
+            jump: "KeyI",
+            punch: "KeyH",
+            block: "KeyK",
+          },
+        },
+      ],
+      pressed: new Set(),
+      matchOver: false,
+    };
+
+    const statusText = document.getElementById("status-text");
+    const p1Health = document.getElementById("p1-health");
+    const p2Health = document.getElementById("p2-health");
+    const roundIndicator = document.getElementById("round-indicator");
+
+    const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+    let animationId = null;
+
+    const resetRound = () => {
+      state.round += 1;
+      state.matchOver = false;
+      state.pressed.clear();
+      state.fighters[0].x = 180;
+      state.fighters[1].x = 640;
+      state.fighters.forEach((fighter) => {
+        fighter.health = 100;
+        fighter.vx = 0;
+        fighter.vy = 0;
+        fighter.blocking = false;
+        fighter.punching = false;
+        fighter.punchCooldown = 0;
+        fighter.y = 0;
+      });
+      roundIndicator.textContent = `Round ${state.round}`;
+    };
+
+    const startLoop = () => {
+      if (animationId === null) {
+        animationId = requestAnimationFrame(loop);
+      }
+    };
+
+    document.getElementById("reset").addEventListener("click", () => {
+      resetRound();
+      startLoop();
+    });
+
+    const updateHealthBars = () => {
+      [p1Health, p2Health].forEach((bar, index) => {
+        const fighter = state.fighters[index];
+        const health = clamp(fighter.health, 0, 100);
+        bar.style.width = `${health}%`;
+        bar.classList.toggle("danger", health <= 30);
+      });
+    };
+
+    const resizeArena = () => {
+      const rect = canvas.getBoundingClientRect();
+      const scale = window.devicePixelRatio || 1;
+      canvas.width = Math.floor(rect.width * scale);
+      canvas.height = Math.floor(rect.height * scale);
+      ctx.setTransform(scale, 0, 0, scale, 0, 0);
+      state.arenaWidth = rect.width;
+      state.arenaHeight = rect.height;
+      state.ground = state.arenaHeight - 90;
+      state.fighters.forEach((fighter) => {
+        fighter.x = clamp(fighter.x, 20, state.arenaWidth - fighter.width - 20);
+      });
+    };
+
+    const drawBackground = () => {
+      const gradient = ctx.createLinearGradient(0, 0, 0, state.arenaHeight);
+      gradient.addColorStop(0, "#30395a");
+      gradient.addColorStop(1, "#1a2032");
+      ctx.fillStyle = gradient;
+      ctx.fillRect(0, 0, state.arenaWidth, state.arenaHeight);
+
+      ctx.fillStyle = "#20263b";
+      ctx.fillRect(0, state.ground, state.arenaWidth, state.arenaHeight - state.ground);
+
+      ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
+      for (let i = 0; i < state.arenaWidth; i += 140) {
+        ctx.fillRect(i, state.ground + 10, 60, 6);
+      }
+    };
+
+    const drawFighter = (fighter, facingLeft) => {
+      ctx.save();
+      ctx.translate(fighter.x, fighter.y);
+      ctx.fillStyle = fighter.color;
+      ctx.fillRect(0, 0, fighter.width, fighter.height);
+
+      ctx.fillStyle = "rgba(0,0,0,0.3)";
+      ctx.fillRect(10, 20, fighter.width - 20, 18);
+
+      if (fighter.blocking) {
+        ctx.strokeStyle = "#feca57";
+        ctx.lineWidth = 4;
+        ctx.strokeRect(-6, -6, fighter.width + 12, fighter.height + 12);
+      }
+
+      if (fighter.punching) {
+        ctx.fillStyle = "#feca57";
+        const punchX = facingLeft ? -18 : fighter.width + 4;
+        ctx.fillRect(punchX, 40, 18, 14);
+      }
+
+      ctx.restore();
+    };
+
+    const resolveAttacks = () => {
+      const [p1, p2] = state.fighters;
+      const fighters = [p1, p2];
+      fighters.forEach((attacker, index) => {
+        const defender = fighters[1 - index];
+        if (!attacker.punching || attacker.punchCooldown > 0) {
+          return;
+        }
+
+        const range = 40;
+        const distance = Math.abs(attacker.x - defender.x);
+        if (distance < attacker.width + range) {
+          const damage = defender.blocking ? 4 : 10;
+          defender.health = clamp(defender.health - damage, 0, 100);
+          attacker.punchCooldown = 18;
+        }
+      });
+    };
+
+    const updatePhysics = () => {
+      state.fighters.forEach((fighter) => {
+        fighter.x += fighter.vx;
+        fighter.y += fighter.vy;
+        fighter.vy += state.gravity;
+
+        if (fighter.y + fighter.height >= state.ground) {
+          fighter.y = state.ground - fighter.height;
+          fighter.vy = 0;
+        }
+
+        fighter.x = clamp(fighter.x, 20, state.arenaWidth - fighter.width - 20);
+        fighter.punchCooldown = Math.max(0, fighter.punchCooldown - 1);
+      });
+    };
+
+    const updateStatus = () => {
+      const [p1, p2] = state.fighters;
+      if (p1.health <= 0 || p2.health <= 0) {
+        state.matchOver = true;
+        const winner = p1.health > 0 ? p1 : p2;
+        const loser = p1.health > 0 ? p2 : p1;
+        statusText.innerHTML = `<span><strong>${winner.name}:</strong> Winner!</span><span><strong>${loser.name}:</strong> K.O.</span><span><strong>Tip:</strong> Press Space/Enter or Restart.</span>`;
+        roundIndicator.textContent = `Round ${state.round} - K.O.`;
+      } else {
+        statusText.innerHTML = `<span><strong>${p1.name}:</strong> ${p1.blocking ? "Blocking" : p1.punching ? "Punching" : "Ready"}</span><span><strong>${p2.name}:</strong> ${p2.blocking ? "Blocking" : p2.punching ? "Punching" : "Ready"}</span><span><strong>Tip:</strong> Press Space/Enter or Restart after K.O.</span>`;
+      }
+    };
+
+    const handleInput = () => {
+      state.fighters.forEach((fighter) => {
+        fighter.vx = 0;
+        fighter.blocking = state.pressed.has(fighter.controls.block);
+        fighter.punching = state.pressed.has(fighter.controls.punch);
+
+        if (state.pressed.has(fighter.controls.left)) {
+          fighter.vx = -4.2;
+        }
+        if (state.pressed.has(fighter.controls.right)) {
+          fighter.vx = 4.2;
+        }
+        if (state.pressed.has(fighter.controls.jump) && fighter.vy === 0) {
+          fighter.vy = -13;
+        }
+      });
+    };
+
+    const loop = () => {
+      drawBackground();
+      if (!state.matchOver) {
+        handleInput();
+        resolveAttacks();
+        updatePhysics();
+      }
+
+      const [p1, p2] = state.fighters;
+      drawFighter(p1, p1.x > p2.x);
+      drawFighter(p2, p2.x > p1.x);
+
+      updateHealthBars();
+      updateStatus();
+
+      animationId = requestAnimationFrame(loop);
+    };
+
+    const isControlKey = (code) =>
+      [
+        "KeyA",
+        "KeyD",
+        "KeyW",
+        "KeyS",
+        "KeyF",
+        "KeyJ",
+        "KeyL",
+        "KeyI",
+        "KeyK",
+        "KeyH",
+        "Space",
+      ].includes(code);
+
+    window.addEventListener("keydown", (event) => {
+      if (isControlKey(event.code)) {
+        event.preventDefault();
+        state.pressed.add(event.code);
+      }
+      if (state.matchOver && (event.code === "Space" || event.code === "Enter")) {
+        resetRound();
+        startLoop();
+      }
+    });
+
+    window.addEventListener("keyup", (event) => {
+      if (isControlKey(event.code)) {
+        event.preventDefault();
+        state.pressed.delete(event.code);
+      }
+    });
+
+    window.addEventListener("blur", () => {
+      state.pressed.clear();
+    });
+
+    resizeArena();
+    window.addEventListener("resize", resizeArena);
+
+    updateHealthBars();
+    startLoop();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- The game could render a blank screen or draw at incorrect sizes because the canvas context wasn't validated and rendering used raw pixel dimensions instead of logical arena dimensions, causing layout and clipping issues on high-DPI displays.
- The change ensures the game presents a clear fallback when the canvas API isn't available and keeps gameplay bounds consistent across window resizes and device pixel ratios.

### Description
- Add a guard that checks `canvas.getContext('2d')` and renders a readable fallback message if the canvas API is unavailable via an early error throw. 
- Introduce `resizeArena()` which computes logical arena dimensions using `getBoundingClientRect()` and `window.devicePixelRatio`, updates `canvas.width`/`canvas.height`, calls `ctx.setTransform(...)`, and recomputes `state.ground`, `state.arenaWidth`, and `state.arenaHeight`.
- Replace uses of `canvas.width`/`canvas.height` with `state.arenaWidth`/`state.arenaHeight` in background drawing and ground math, and clamp fighter positions against `state.arenaWidth` to keep entities within the visible area.
- Call `resizeArena()` on load and attach it to `window.resize` so the render loop draws at correct sizes and scales on DPI changes.

### Testing
- Started a static server with `python -m http.server 8001` which served the page successfully. 
- Ran a Playwright smoke script that loaded `http://127.0.0.1:8001/streetfighter2.html` and saved a screenshot to `artifacts/streetfighter2.png`, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d16d28ad08320889b45251b887240)